### PR TITLE
Added option for mode (e.g. bind vs. connect) to camel-zeromq

### DIFF
--- a/components/camel-zeromq/src/main/java/org/apacheextras/camel/component/zeromq/Listener.java
+++ b/components/camel-zeromq/src/main/java/org/apacheextras/camel/component/zeromq/Listener.java
@@ -66,9 +66,15 @@ class Listener implements Runnable {
         socket = akkaSocketFactory.createConsumerSocket(context, endpoint.getSocketType());
 
         String addr = endpoint.getSocketAddress();
-        LOGGER.info("Connecting to server [{}]", addr);
-        socket.connect(addr);
-        LOGGER.info("Connected OK");
+        if (endpoint.getMode() == null || endpoint.getMode().equals("CONNECT")) {
+            LOGGER.info("Connecting to server [{}]", addr);
+            socket.connect(addr);
+            LOGGER.info("Connected OK");
+        } else {
+            LOGGER.info("Binding to server [{}]", addr);
+            socket.bind(addr);
+            LOGGER.info("Bound OK");
+        }
 
         if (endpoint.getSocketType() == ZeromqSocketType.SUBSCRIBE) {
             subscribe();

--- a/components/camel-zeromq/src/main/java/org/apacheextras/camel/component/zeromq/ZeromqEndpoint.java
+++ b/components/camel-zeromq/src/main/java/org/apacheextras/camel/component/zeromq/ZeromqEndpoint.java
@@ -44,8 +44,9 @@ public class ZeromqEndpoint extends DefaultEndpoint {
     private long highWaterMark = -1;
     private long linger = -1;
     private String topics;
+    private String mode;
     private boolean asyncConsumer = true;
-    private Class messageConvertor = DefaultMessageConvertor.class;
+    private Class<?> messageConvertor = DefaultMessageConvertor.class;
     private SocketFactory socketFactory;
     private ContextFactory contextFactory;
 
@@ -123,6 +124,7 @@ public class ZeromqEndpoint extends DefaultEndpoint {
         return linger;
     }
 
+    @SuppressWarnings("rawtypes")
     public Class getMessageConvertor() {
         return messageConvertor;
     }
@@ -146,6 +148,10 @@ public class ZeromqEndpoint extends DefaultEndpoint {
 
     public String getTopics() {
         return topics;
+    }
+
+    public String getMode() {
+        return mode;
     }
 
     public boolean isAsyncConsumer() {
@@ -172,7 +178,7 @@ public class ZeromqEndpoint extends DefaultEndpoint {
         this.linger = linger;
     }
 
-    public void setMessageConvertor(Class messageConvertor) {
+    public void setMessageConvertor(Class<?> messageConvertor) {
         this.messageConvertor = messageConvertor;
     }
 
@@ -190,6 +196,10 @@ public class ZeromqEndpoint extends DefaultEndpoint {
 
     public void setTopics(String topics) {
         this.topics = topics;
+    }
+
+    public void setMode(String mode) {
+        this.mode = mode;
     }
 
 }

--- a/components/camel-zeromq/src/main/java/org/apacheextras/camel/component/zeromq/ZeromqProducer.java
+++ b/components/camel-zeromq/src/main/java/org/apacheextras/camel/component/zeromq/ZeromqProducer.java
@@ -93,9 +93,15 @@ public class ZeromqProducer extends DefaultProducer {
         this.topics = endpoint.getTopics() == null ? null : endpoint.getTopics().split(",");
 
         String addr = endpoint.getSocketAddress();
-        LOGGER.info("Binding client to [{}]", addr);
-        socket.bind(addr);
-        LOGGER.info("Client bound OK");
+        if (endpoint.getMode() == null || endpoint.getMode().equals("BIND")) {
+            LOGGER.info("Binding client to [{}]", addr);
+            socket.bind(addr);
+            LOGGER.info("Bound OK");
+        } else {
+            LOGGER.info("Connecting client to [{}]", addr);
+            socket.connect(addr);
+            LOGGER.info("Connected OK");
+        }
     }
 
     @Override

--- a/components/camel-zeromq/src/test/java/org/apacheextras/camel/component/zeromq/ZeromqProducerTest.java
+++ b/components/camel-zeromq/src/test/java/org/apacheextras/camel/component/zeromq/ZeromqProducerTest.java
@@ -165,4 +165,18 @@ public class ZeromqProducerTest {
         producer.stop();
         t.join();
     }
+
+    @Test
+    public void bind() throws Exception {
+    	// BIND mode by default
+    	producer.start();
+    	verify(socket).bind(endpoint.getSocketAddress());
+    }
+
+    @Test
+    public void connect() throws Exception {
+    	when(endpoint.getMode()).thenReturn("CONNECT");
+    	producer.start();
+    	verify(socket).connect(endpoint.getSocketAddress());
+    }
 }


### PR DESCRIPTION
Occasionally, there are situations where the bind/connect model in ZMQ is inverted, and senders are dynamic, receivers are static, for example when building distributed logging systems. In this case, we need a configurable option to select the "mode".

This P/R adds this ability, leaving the default as the current behavior for producers and consumers. Example usage:

```
// one subscriber
from("zeromq:tcp://127.0.0.1:5555?socketType=SUBSCRIBE&mode=BIND")
  to("direct:xyz");

// many publishers
from("direct:xyz")
  to("zeromq:tcp://my.logging.server:5555?socketType=PUBLISH&mode=CONNECT");
```
